### PR TITLE
Introduce 'label' field for countries

### DIFF
--- a/src/components/start-screen/area-list/AreaList.js
+++ b/src/components/start-screen/area-list/AreaList.js
@@ -9,27 +9,27 @@ export default (props) => (
     className="d-flex no-gutters
         flex-column align-items-stretch
         flex-sm-row flex-sm-wrap justify-content-sm-center align-items-sm-center
-        pt-md-2 pb-md-2 align-content-md-start text-capitalize">
+        pt-md-2 pb-md-2 align-content-md-start">
     {props.items.map(i => (
-      <div className="col-12 col-lg-6" key={i}>
+      <div className="col-12 col-lg-6" key={i.id}>
         <div className="bg-faded
           p-3 p-sm-4
           mb-2 mb-sm-3 m-lg-3">
-          <h3 className="mb-4">{i}</h3>
+          <h3 className="mb-4">{i.label}</h3>
           <div className="d-flex no-gutters gg-area">
             <div className="col-6 col-sm-4 gg-area-buttons">
               <div className="mt-1 mb-2">
-                <Link className="btn btn-outline-primary" to={{pathname: i + '/countryName'}}>Country name</Link>
+                <Link className="btn btn-outline-primary" to={{pathname: i.id + '/countryName'}}>Country Name</Link>
               </div>
               <div className="mt-1 mb-2">
-                <Link className="btn btn-outline-primary" to={{pathname: i + '/capital'}}>Capital</Link>
+                <Link className="btn btn-outline-primary" to={{pathname: i.id + '/capital'}}>Capital</Link>
               </div>
               <div className="mt-1 mb-2">
-                <Link className="btn btn-outline-primary" to={{pathname: i + '/flag'}}>Flag</Link>
+                <Link className="btn btn-outline-primary" to={{pathname: i.id + '/flag'}}>Flag</Link>
               </div>
             </div>
             <div className="col-sm-8 gg-area-icon">
-              <Continents active={i}/>
+              <Continents active={i.id}/>
             </div>
           </div>
         </div>

--- a/src/services/countriesService.js
+++ b/src/services/countriesService.js
@@ -1,15 +1,15 @@
 /* globals fetch */
 
 export const areas = [
-  'africa',
-  'asia',
-  'europe',
-  'north-america',
-  'oceania',
-  'south-america',
+  { id: 'africa', label: 'Africa' },
+  { id: 'asia', label: 'Asia' },
+  { id: 'europe', label: 'Europe' },
+  { id: 'north-america', label: 'North America' },
+  { id: 'oceania', label: 'Oceania' },
+  { id: 'south-america', label: 'South America' },
 ];
 
-export const isAreaIdValid = (id) => areas.indexOf(id) !== -1;
+export const isAreaIdValid = (id) => areas.some(i => i.id === id);
 
 export const fetchData = (id) => {
   if (!isAreaIdValid(id)) {
@@ -33,32 +33,32 @@ export const getMapConfigFromAreaId = id => {
   };
 
   switch (id) {
-    case areas[0]:
+    case areas[0].id:
       return {
         center: [0, 20],
         zoom: defaultMapZoom
       };
-    case areas[1]:
+    case areas[1].id:
       return {
         center: [25, 90],
         zoom: defaultMapZoom
       };
-    case areas[2]:
+    case areas[2].id:
       return {
         center: [50, 0],
         zoom: defaultMapZoom
       };
-    case areas[3]:
+    case areas[3].id:
       return {
         center: [40, -100],
         zoom: defaultMapZoom
       };
-    case areas[4]:
+    case areas[4].id:
       return {
         center: [-25, 150],
         zoom: defaultMapZoom
       };
-    case areas[5]:
+    case areas[5].id:
       return {
         center: [-30, -60],
         zoom: {


### PR DESCRIPTION
Currently, North America is spelled as “North-America” simply because it's the identifier 'north-america' transformed to capital case by CSS. This sounds like a hack ;)
I've introduced a 2nd property to the `areas` array so that `id` and `label` stay apart, and there's no need anymore to resort to CSS to solve this.